### PR TITLE
Remove potential monkeypatch call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.1.1 (TBD)
+
+Fixes:
+
+* Do not leverage #to_datetime even if it is available for date parsing.  This removes un-intentional coupling of other libraries into Realize and keeps it based on Ruby standard and core libraries.
+
 # 1.1.0 (June 24th, 2020)
 
 Addition of r/collection/at_index, r/collection/first, and r/collection/last

--- a/lib/realize/format/date.rb
+++ b/lib/realize/format/date.rb
@@ -30,12 +30,10 @@ module Realize
         return nil if value.to_s.empty?
 
         date_time =
-          if value.respond_to?(:to_datetime)
-            value.to_datetime
-          elsif input_format?
+          if input_format?
             DateTime.strptime(value, input_format)
           else
-            DateTime.parse(value)
+            DateTime.parse(value.to_s)
           end
 
         date_time.strftime(output_format)

--- a/lib/realize/version.rb
+++ b/lib/realize/version.rb
@@ -8,5 +8,5 @@
 #
 
 module Realize
-  VERSION = '1.1.0'
+  VERSION = '1.1.1-alpha'
 end


### PR DESCRIPTION
A higher level application is currently using the [Timecop](https://github.com/travisjeffery/timecop) library and it is causing parsing issues with dates.  This PR removes the potential for this collision and keeps Realize more pure (based only on Ruby's core and standard libraries.)