### PR TITLE
Initial implementation of boolean, string, uuid, and now transformers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.2.0 (TBD)
+# 1.2.0 (October 6th, 2020)
 
 New Transformers:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 1.2.0 (TBD)
+
+New Transformers:
+
+* b/type/boolean
+* b/type/string
+* b/value/now
+* b/value/uuid
+
 # 1.1.1 (September 9th, 2020)
 
 Fixes:

--- a/README.md
+++ b/README.md
@@ -84,13 +84,20 @@ Here is a list of each built-in transformer, their options, and what their funct
 
 * **r/logical/switch** [cases, default_transformers, key]: Provides a value-based logic branching.  If a value matches a specific case, the specific cases transformers will be executed.  If it does not match any case then the default_transformers will be executed.
 
+#### Type Transformers
+
+* **r/type/boolean** [nullable]: Returns `true` if the input is 'truthy', `false` if not.  By default nullable is false, which means a nil input will return false.  Changing this to true will return nil if nil is passed in.  A 'truthy' value is defined as matching: true, t, yes, y, or 1 (case-insensitive).
+* **r/type/string** []: Calls `#to_s` on the value so the returned value is guaranteed to be a string type.
+
 #### Value-oriented Transformers
 
 * **r/value/blank** []: Always return a blank string.
 * **r/value/map** [values]: Do a lookup on the value using the `values` hash.  If a value is found, then its corresponding value is returned.  If it isn't then the input is returned.
+* **r/value/now** [utc_offset]: Returns a Time object, defaulting to UTC offset.  You can optionally pass in a different offset in the FORM: "+/-HH:MM"
 * **r/value/null** []: Always returns null.
 * **r/value/resolve** [key]: Dynamically resolves a value based on the record's key.  It uses the [Objectable](https://github.com/bluemarblepayroll/objectable) library by default, which provides some goodies like dot-notation for nested objects and type-insensitivity (works for Ruby objects, hashes, structs, etc.)
 * **r/value/static** [value]: Always returns a hard-coded value.
+* **r/value/uuid** []: Returns a new 36 character UUID (i.e. 6967fec6-bbde-4497-82d9-55ccc7b87cd0)
 * **r/value/verbatim** []: Default transformer, simply echos back the input.
 
 ### Plugging in Transformers

--- a/lib/realize.rb
+++ b/lib/realize.rb
@@ -9,6 +9,7 @@
 
 require 'acts_as_hashable'
 require 'objectable'
+require 'securerandom'
 require 'time'
 
 require_relative 'realize/arrays'

--- a/lib/realize/transformers.rb
+++ b/lib/realize/transformers.rb
@@ -4,19 +4,28 @@ require_relative 'collection/at_index'
 require_relative 'collection/first'
 require_relative 'collection/last'
 require_relative 'collection/sort'
+
 require_relative 'filter/by_key_record_value'
 require_relative 'filter/by_key_value'
 require_relative 'filter/by_key_value_presence'
 require_relative 'filter/inactive'
+
 require_relative 'format/date'
 require_relative 'format/remove_whitespace'
 require_relative 'format/string_replace'
+
 require_relative 'logical/switch'
+
+require_relative 'type/boolean'
+require_relative 'type/string'
+
 require_relative 'value/blank'
 require_relative 'value/map'
+require_relative 'value/now'
 require_relative 'value/null'
 require_relative 'value/resolve'
 require_relative 'value/static'
+require_relative 'value/uuid'
 require_relative 'value/verbatim'
 
 module Realize
@@ -27,24 +36,32 @@ module Realize
   class Transformers
     acts_as_hashable_factory
 
-    register '',                               Value::Verbatim
     register 'r/collection/at_index',          Collection::AtIndex
     register 'r/collection/first',             Collection::First
     register 'r/collection/last',              Collection::Last
     register 'r/collection/sort',              Collection::Sort
+
     register 'r/filter/by_key_record_value',   Filter::ByKeyRecordValue
     register 'r/filter/by_key_value',          Filter::ByKeyValue
     register 'r/filter/by_key_value_presence', Filter::ByKeyValuePresence
     register 'r/filter/inactive',              Filter::Inactive
+
     register 'r/format/date',                  Format::Date
     register 'r/format/remove_whitespace',     Format::RemoveWhitespace
     register 'r/format/string_replace',        Format::StringReplace
+
     register 'r/logical/switch',               Logical::Switch
+
+    register 'r/type/boolean',                 Type::Boolean
+    register 'r/type/string',                  Type::String
+
     register 'r/value/blank',                  Value::Blank
     register 'r/value/map',                    Value::Map
+    register 'r/value/now',                    Value::Now
     register 'r/value/null',                   Value::Null
     register 'r/value/resolve',                Value::Resolve
     register 'r/value/static',                 Value::Static
-    register 'r/value/verbatim',               Value::Verbatim
+    register 'r/value/uuid',                   Value::Uuid
+    register 'r/value/verbatim', '',           Value::Verbatim
   end
 end

--- a/lib/realize/type/boolean.rb
+++ b/lib/realize/type/boolean.rb
@@ -6,8 +6,9 @@ module Realize
     # By default nils will return false unless nullable: true is passed in.
     # This transformer is very liberal in its parsing and will return true for:
     #   true, 'true', 't', 'TRUE', 'True', 1, '1', 'Y', 'yes', 'Yes', 'YES'
-    # All over non-truthy values will evaluate to false, such as:
-    #   false: false, 'false', 'f', 'FALSE', 'False', 0, '0', 'N', 'no', 'No', 'NO', {}, [], ''
+    # All other non-truthy values will evaluate to false, such as:
+    #   false, 'false', 'f', 'FALSE', 'False', 0, '0', 'N', 'no', 'No', 'NO', {}, [], '',
+    #   'abc', 123, :abc, etc...
     class Boolean
       acts_as_hashable
 

--- a/lib/realize/type/boolean.rb
+++ b/lib/realize/type/boolean.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Realize
+  class Type
+    # Convert input into either true, false, or nil.
+    # By default nils will return false unless nullable: true is passed in.
+    # This transformer is very liberal in its parsing and will return true for:
+    #   true, 'true', 't', 'TRUE', 'True', 1, '1', 'Y', 'yes', 'Yes', 'YES'
+    # All over non-truthy values will evaluate to false, such as:
+    #   false: false, 'false', 'f', 'FALSE', 'False', 0, '0', 'N', 'no', 'No', 'NO', {}, [], ''
+    class Boolean
+      acts_as_hashable
+
+      attr_reader :nullable
+
+      def initialize(nullable: false)
+        @nullable = nullable || false
+      end
+
+      def transform(_resolver, value, _time, _record)
+        if nullable && value.nil?
+          nil
+        elsif truthy?(value)
+          true
+        else
+          false
+        end
+      end
+
+      private
+
+      def truthy?(value)
+        value.to_s.match?(/(true|t|yes|y|1)$/i)
+      end
+    end
+  end
+end

--- a/lib/realize/type/string.rb
+++ b/lib/realize/type/string.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Realize
+  class Type
+    # Call #to_s on the value and return result.
+    class String
+      acts_as_hashable
+
+      attr_reader :nullable
+
+      def initialize(nullable: false)
+        @nullable = nullable || false
+      end
+
+      def transform(_resolver, value, _time, _record)
+        return nil if nullable && value.nil?
+
+        value.to_s
+      end
+    end
+  end
+end

--- a/lib/realize/value/now.rb
+++ b/lib/realize/value/now.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Realize
+  class Value
+    # Return a current Time object.
+    class Now
+      acts_as_hashable
+
+      DEFAULT_UTC_OFFSET = '+00:00'
+
+      attr_reader :utc_offset
+
+      def initialize(utc_offset: DEFAULT_UTC_OFFSET)
+        @utc_offset = utc_offset || DEFAULT_UTC_OFFSET
+
+        freeze
+      end
+
+      def transform(_resolver, _value, _time, _record)
+        Time.now.utc.localtime(utc_offset)
+      end
+    end
+  end
+end

--- a/lib/realize/value/uuid.rb
+++ b/lib/realize/value/uuid.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Realize
+  class Value
+    # Return a current Time object.
+    class Uuid
+      acts_as_hashable
+
+      def transform(_resolver, _value, _time, _record)
+        SecureRandom.uuid
+      end
+    end
+  end
+end

--- a/lib/realize/version.rb
+++ b/lib/realize/version.rb
@@ -8,5 +8,5 @@
 #
 
 module Realize
-  VERSION = '1.1.1'
+  VERSION = '1.2.0-alpha'
 end

--- a/lib/realize/version.rb
+++ b/lib/realize/version.rb
@@ -8,5 +8,5 @@
 #
 
 module Realize
-  VERSION = '1.2.0-alpha'
+  VERSION = '1.2.0'
 end

--- a/spec/realize/type/boolean_spec.rb
+++ b/spec/realize/type/boolean_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Realize::Type::Boolean do
+  let(:record)     { {} }
+  let(:resolver)   { nil }
+  let(:time)       { nil }
+
+  subject { described_class.make(nullable: nullable) }
+
+  describe '#transform' do
+    context 'nullable' do
+      let(:nullable) { true }
+
+      it 'returns nil when nil is passed in' do
+        actual = subject.transform(resolver, nil, time, record)
+
+        expect(actual).to be nil
+      end
+    end
+
+    context 'not nullable' do
+      TEST_CASES = [
+        [nil, false],
+        [true, true],
+        ['t', true],
+        ['true', true],
+        ['TRUE', true],
+        ['True', true],
+        ['1', true],
+        ['Y', true],
+        ['y', true],
+        ['yes', true],
+        ['YES', true],
+        ['Yes', true],
+        [false, false],
+        ['f', false],
+        ['false', false],
+        ['FALSE', false],
+        ['False', false],
+        ['0', false],
+        ['N', false],
+        ['n', false],
+        ['no', false],
+        ['NO', false],
+        ['No', false],
+        ['', false],
+        [{}, false]
+      ].freeze
+
+      let(:nullable) { false }
+
+      TEST_CASES.each do |test_case|
+        input_value    = test_case[0]
+        expected_value = test_case[1]
+
+        it "#{input_value} should return #{expected_value}" do
+          actual = subject.transform(resolver, input_value, time, record)
+
+          expect(actual).to eq(expected_value)
+        end
+      end
+    end
+  end
+end

--- a/spec/realize/type/string_spec.rb
+++ b/spec/realize/type/string_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Realize::Type::String do
+  let(:record)     { {} }
+  let(:resolver)   { nil }
+  let(:time)       { nil }
+
+  subject { described_class.make(nullable: nullable) }
+
+  describe '#transform' do
+    context 'nullable' do
+      let(:nullable) { true }
+
+      it 'returns nil if nil is passed in' do
+        actual = subject.transform(resolver, nil, time, record)
+
+        expect(actual).to be nil
+      end
+
+      it 'returns a string if anything not nil is passed in' do
+        [23.45, false, true, Time.now, {}, []].each do |value|
+          actual = subject.transform(resolver, value, time, record)
+
+          expect(actual).to be_a(String)
+        end
+      end
+    end
+  end
+
+  context 'not nullable' do
+    let(:nullable) { false }
+
+    it 'returns a string' do
+      [nil, 23.45, false, true, Time.now, {}, []].each do |value|
+        actual = subject.transform(resolver, value, time, record)
+
+        expect(actual).to be_a(String)
+      end
+    end
+  end
+end

--- a/spec/realize/value/now_spec.rb
+++ b/spec/realize/value/now_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Realize::Value::Now do
+  let(:record)     { {} }
+  let(:resolver)   { nil }
+  let(:time)       { nil }
+
+  subject { described_class.make(utc_offset: utc_offset) }
+
+  describe '#transform' do
+    context 'without a custom utc_offset' do
+      let(:utc_offset) { nil }
+
+      it 'returns proper offset' do
+        time = subject.transform(resolver, nil, time, record)
+
+        utc_offset_in_seconds = 0
+
+        expect(time.utc_offset).to eq(utc_offset_in_seconds)
+      end
+    end
+
+    context 'with a custom utc_offset' do
+      let(:utc_offset) { '+02:30' }
+
+      it 'should return a Time instance' do
+        time = subject.transform(resolver, nil, time, record)
+
+        expect(time).to be_a(Time)
+      end
+
+      it 'returns proper offset' do
+        time = subject.transform(resolver, nil, time, record)
+
+        utc_offset_in_seconds = 2.5 * 60 * 60
+
+        expect(time.utc_offset).to eq(utc_offset_in_seconds)
+      end
+
+      it 'returns a time object within normal limits' do
+        lower_limit = Time.now.utc
+
+        time = subject.transform(resolver, nil, time, record)
+
+        upper_limit = Time.now.utc.localtime(utc_offset)
+
+        expect(time).to be >= lower_limit
+        expect(time).to be <= upper_limit
+      end
+    end
+  end
+end

--- a/spec/realize/value/uuid_spec.rb
+++ b/spec/realize/value/uuid_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Realize::Value::Uuid do
+  let(:record)     { {} }
+  let(:resolver)   { nil }
+  let(:time)       { nil }
+
+  describe '#transform' do
+    it 'returns a string with a length of 36' do
+      value = subject.transform(resolver, nil, time, record)
+
+      expect(value.length).to eq(36)
+    end
+
+    it 'returns a unique string' do
+      count = 30
+      ids   = Set.new
+
+      (0...count).each { ids << subject.transform(resolver, nil, time, record) }
+
+      expect(ids.length).to eq(count)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'pry'
+require 'set'
 
 unless ENV['DISABLE_SIMPLECOV'] == 'true'
   require 'simplecov'


### PR DESCRIPTION
This PR contains four new transformers:

1. type/boolean: coerces a value to a boolean type
2. type/string: coerces a value to a string type
3. value/now: returns a Time object based on the current date and time
4. value/uuid: returns a new UUID, such as: 6967fec6-bbde-4497-82d9-55ccc7b87cd0 